### PR TITLE
feat: add a simple main function to load gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10167,6 +10167,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-vm-runtime",
+ "mysten-metrics",
  "network",
  "prometheus",
  "prometheus-parse",
@@ -10187,6 +10188,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
+ "tracing-subscriber",
  "typed-store",
 ]
 
@@ -15614,6 +15616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15625,7 +15638,7 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3",
  "tracing-subscriber",
 ]
 
@@ -15641,9 +15654,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -15657,7 +15670,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
  "tracing-serde",
 ]
 

--- a/crates/remora/Cargo.toml
+++ b/crates/remora/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = "0.11.22"
 sha3 = "0.10.8"
 better_any = "0.2.0"
 itertools = "0.13.0"
+tracing-subscriber = "0.3.18"
 
 prometheus-parse = { git = "https://github.com/asonnino/prometheus-parser.git", rev = "75334db" }
 
@@ -40,6 +41,8 @@ sui-protocol-config = { path = "../sui-protocol-config" }
 sui-adapter-latest = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
 sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
 move-vm-runtime = { path = "../../external-crates/move/crates/move-vm-runtime" }
+mysten-metrics = { path = "../mysten-metrics" }
+
 network = { path = "network" }
 
 typed-store.workspace = true

--- a/crates/remora/src/lib.rs
+++ b/crates/remora/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod agents;
 pub mod input_traffic_manager;
-pub mod load_generator;
 pub mod metrics;
 pub mod mock_consensus_worker;
 pub mod pre_exec_agent;


### PR DESCRIPTION
This will allow us to build scripts to call the load generator independently of the rest of the binaries. It will be useful later on when we will instrument independent AWS machines to run load generators.